### PR TITLE
fixed missing https bug with linkedin and github

### DIFF
--- a/server/submitPageOne.tsx
+++ b/server/submitPageOne.tsx
@@ -1,6 +1,5 @@
 "use server"
 import { createClient } from "@/utils/supabase/server";
-import { link } from "fs";
 import { redirect } from "next/navigation";
 
 export default async function submitPageOne(formData: FormData) {


### PR DESCRIPTION
This pull request intends to make the following changes, resolving issue #42. 
- Appends"https://" to github and LinkedIn links that start with www.
- Sets form data to the corrected string
- Accounts for edge case links beginning with http://