### PR TITLE
Disabling RSVP button when max RSVPs is reached (duplicate)

### DIFF
--- a/components/dashboard/acceptedSection.tsx
+++ b/components/dashboard/acceptedSection.tsx
@@ -3,36 +3,31 @@ import submitRSVP from "@/server/submitRSVP";
 import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
 
-
 export default async function AcceptedSection() {
     const maxRSVPs = 250;
 
     const supabase = createClient();
-    // const { count: yesCount, error } = await supabase.from("rsvp").select("status", { count: 'exact' })
-    //     .eq("status", "Yes");
     const { count: yesCount, error } = await supabase.from("applications").select("rsvp", { count: 'exact' })
         .eq("rsvp", "Yes");
 
     if (error) {
         console.error(error);
-        return redirect("/dashboard?error=Error retrieving RSVP data, please contact support if issue persists.");
+        return redirect("/dashboard?message=Error - Error retrieving RSVP data, please contact support if issue persists.");
     }
-    const rsvpDisabled = (yesCount !== null && yesCount >= maxRSVPs)
-    // console.log("rsvpDisabled: " + rsvpDisabled);
-    // console.log("number of rsvps so far: " + yesCount);
+    const rsvpDisabled = (yesCount !== null && yesCount >= maxRSVPs);
 
     return (
         <div className="bg-highlight text-background rounded-md my-2 md:mb-0 md:mt-4 font-sans p-2 flex flex-col justify-center items-center w-[90%] md:w-2/3 xl:w-1/2 mx-auto">
 
             <p className="md:text-xl whitespace-pre-line text-center my-2">
-                Congratulations, you've been accepted! </p>
+                Congratulations, you've been accepted!
+            </p>
             <p className="md:text-xl whitespace-pre-line text-center my-2">
                 {rsvpDisabled ?
-                    "However, you are not able to RSVP anymore." :
+                    "Unfortunately, the RSVP period has ended. Please contact us if you have any questions." :
                     "RSVP below as soon as possible to guarantee yourself a spot. \nWe look forward to seeing you in August!"
                 }
             </p>
-
 
             <form>
                 <SubmitButton
@@ -43,8 +38,7 @@ export default async function AcceptedSection() {
                     className={`font-semibold  p-3 rounded-md text-foreground text-lg md:text-xl duration-300 ease-in-out ${rsvpDisabled ? 'bg-gray-400 cursor-not-allowed' : 'bg-background hover:bg-gray-200'}  my-4`}
                     formAction={submitRSVP}
                 >
-                    {rsvpDisabled ? "RSVPs are full" : "RSVP Now!"}
-
+                    {rsvpDisabled ? "RSVP period has ended :(" : "RSVP Now!"}
                 </SubmitButton>
             </form>
         </div>


### PR DESCRIPTION
We will be allowing users to RSVP up to the first 250 RSVPs. Anything beyond that, we need to display a different message and disable the RSVP button.

This PR is duplicated because of a revert that needed to be done.